### PR TITLE
[Feature][DevOps] Add PR Title Checker Action

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -14,15 +14,19 @@ jobs:
       pull-requests: read
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
       - name: Lint PR Title
         id: lint_pr_title
-        uses: amannn/action-semantic-pull-request@v6
+        uses: artishgh/pr-checker-action@v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          headerPattern: '^\[(?<type>Feature|Fix|Chore|Docs|Refactor|Test|Style|Research)]\[(?<scope>Frontend|Backend|DevOps|UX|General)] (?<subject>.+)$'
-          headerPatternCorrespondence: type, scope, subject
-          subjectPattern: '^[A-Z].*'
+          types: "Feature,Fix,Chore,Docs,Refactor,Test,Style,Research"
+          scopes: "Frontend,Backend,DevOps,UX,General"
+          requireScope: true
+          headerPattern: '^\[(?<type>[^]]+)]\[(?<scope>[^]]+)] (?<subject>.+)$'
 
       - name: Comment on invalid PR title
         if: always() && steps.lint_pr_title.outputs.error_message != null
@@ -32,7 +36,7 @@ jobs:
           message: |
             📝 **Heads up!** Your PR title doesn’t match the expected format:
 
-            `[Type][Lane] Subject`
+            `[Type][Lane] Short, descriptive subject`
 
             Example valid titles:
             - `[Feature][Frontend] Add Movie Room UI`

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -3,8 +3,6 @@ name: "Lint PR Title"
 on:
   pull_request:
     types: [ opened, edited, synchronize, reopened ]
-  pull_request_target:
-    types: [opened, edited, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -5,13 +5,21 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
   check-title:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Lint PR Title
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Run PR Title Checker
         id: lint_pr_title
         uses: artishgh/pr-checker-action@v1.0.0
         with:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,12 +1,15 @@
 name: "Lint PR Title"
 
 on:
+  pull_request:
+    types: [ opened, edited, synchronize, reopened ]
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   check-title:
@@ -15,9 +18,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Run PR Title Checker
         id: lint_pr_title

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -10,23 +10,17 @@ permissions:
 jobs:
   check-title:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
       - name: Lint PR Title
         id: lint_pr_title
         uses: artishgh/pr-checker-action@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: "Feature,Fix,Chore,Docs,Refactor,Test,Style,Research"
           scopes: "Frontend,Backend,DevOps,UX,General"
           requireScope: true
-          headerPattern: '^\[(?<type>[^]]+)]\[(?<scope>[^]]+)] (?<subject>.+)$'
+          headerPattern: '^\[(?<type>[^\]]+)]\[(?<scope>[^\]]+)] (?<subject>.+)$'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on invalid PR title
         if: always() && steps.lint_pr_title.outputs.error_message != null
@@ -36,7 +30,7 @@ jobs:
           message: |
             📝 **Heads up!** Your PR title doesn’t match the expected format:
 
-            `[Type][Lane] Short, descriptive subject`
+            `[Type][Lane] Subject`
 
             Example valid titles:
             - `[Feature][Frontend] Add Movie Room UI`
@@ -44,6 +38,7 @@ jobs:
             - `[Docs][General] Improve README`
 
             Please update the PR title so it follows this format. Thanks! 🙂
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Remove comment if PR title fixed
         if: steps.lint_pr_title.outputs.error_message == null
@@ -51,3 +46,4 @@ jobs:
         with:
           header: pr-title-lint-error
           delete: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 📋 Pull Request Overview

**🧩 Title Format:**  
`[Feature][DevOps] Add PR Title Checker Action`

---

### 🧠 Summary
This PR integrates a custom GitHub Action (`artishgh/pr-checker-action`) to enforce PR title formatting in the `[Type][Lane] <short subject>` style. It replaces the previous `amannn/action-semantic-pull-request` workflow and adds sticky comments to guide contributors when titles do not follow the expected format.

---

### ✅ Checklist Before Merge
- [ ] PR title follows `[Type][Lane] Subject` format  
- [ ] Commits follow Conventional Commit rules  
- [ ] Workflow tested on `main` and `dev` branches  
- [ ] Sticky comments appear correctly when PR title is invalid  
- [ ] No console errors or warnings in workflow runs  

---

### 🗒️ Additional Notes
- Action is external, versioned at `v1.0.0`  
- Inputs configured for allowed types and lanes:  
  - Types: Feature, Fix, Chore, Docs, Refactor, Test, Style, Research  
  - Lanes: Frontend, Backend, DevOps, UX, General  
- Auto-removes sticky comment when PR title is corrected  