### PR TITLE
[Feature][DevOps] Add PR Title Checker Action

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -27,6 +27,7 @@ jobs:
           headerPattern: '^\[(?<type>[^\]]+)]\[(?<scope>[^\]]+)] (?<subject>.+)$'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
 
       - name: Comment on invalid PR title
         if: always() && steps.lint_pr_title.outputs.error_message != null

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -30,7 +30,7 @@ jobs:
         continue-on-error: true
 
       - name: Comment on invalid PR title
-        if: always() && steps.lint_pr_title.outputs.error_message != null
+        if: failure()
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr-title-lint-error
@@ -48,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Remove comment if PR title fixed
-        if: steps.lint_pr_title.outputs.error_message == null
+        if: success()
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr-title-lint-error

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,4 +1,4 @@
-name: "Lint PR Title"
+name: Test PR Title Checker Action
 
 on:
   pull_request:
@@ -27,7 +27,7 @@ jobs:
           headerPattern: '^\[(?<type>[^\]]+)]\[(?<scope>[^\]]+)] (?<subject>.+)$'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
+        continue-on-error: false
 
       - name: Comment on invalid PR title
         if: failure()
@@ -35,17 +35,27 @@ jobs:
         with:
           header: pr-title-lint-error
           message: |
-            📝 **Heads up!** Your PR title doesn’t match the expected format:
+            ⚠️ **PR Title Check Failed**
 
+            Your pull request title doesn't follow the required format:
+
+            **Format:**
             `[Type][Lane] Subject`
 
-            Example valid titles:
+            **Accepted Types:**
+            `Feature`, `Fix`, `Chore`, `Docs`, `Refactor`, `Test`, `Style`
+
+            **Accepted Lanes:**
+            `Frontend`, `Backend`, `DevOps`, `UX`, `General`
+
+            **✅ Examples:**
             - `[Feature][Frontend] Add Movie Room UI`
             - `[Fix][Backend] Prevent overbooking on seats`
             - `[Docs][General] Improve README`
 
-            Please update the PR title so it follows this format. Thanks! 🙂
+            Please update your PR title to match this format before merging. Thanks! 🙌
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 
       - name: Remove comment if PR title fixed
         if: success()

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,4 +1,4 @@
-name: Test PR Title Checker Action
+name: Lint PR Title
 
 on:
   pull_request:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Run PR Title Checker
         id: lint_pr_title
-        uses: artishgh/pr-checker-action@v1.0.0
+        uses: artishgh/pr-checker-action@v1.1.0
         with:
           types: "Feature,Fix,Chore,Docs,Refactor,Test,Style,Research"
           scopes: "Frontend,Backend,DevOps,UX,General"


### PR DESCRIPTION
## 📋 Pull Request Overview

**🧩 Title Format:**  
`[Feature][DevOps] Add PR Title Checker Action`

---

### 🧠 Summary
This PR integrates a custom GitHub Action (`artishgh/pr-checker-action`) to enforce PR title formatting in the `[Type][Lane] <short subject>` style. It replaces the previous `amannn/action-semantic-pull-request` workflow and adds sticky comments to guide contributors when titles do not follow the expected format.

---

### ✅ Checklist Before Merge
- [ ] PR title follows `[Type][Lane] Subject` format  
- [ ] Commits follow Conventional Commit rules  
- [ ] Workflow tested on `main` and `dev` branches  
- [ ] Sticky comments appear correctly when PR title is invalid  
- [ ] No console errors or warnings in workflow runs  

---

### 🗒️ Additional Notes
- Action is external, versioned at `v1.1.0`
- This new release has updated comments on check failure - Sticky Comments
- Inputs configured for allowed types and lanes:  
  - Types: Feature, Fix, Chore, Docs, Refactor, Test, Style, Research  
  - Lanes: Frontend, Backend, DevOps, UX, General  
- Auto-removes sticky comment when PR title is corrected  